### PR TITLE
Use normalizer in loc extractor

### DIFF
--- a/MaintainabilityAnalyzer/src/Analyzers/VolumeAnalyzer.rsc
+++ b/MaintainabilityAnalyzer/src/Analyzers/VolumeAnalyzer.rsc
@@ -5,31 +5,33 @@ import DataTypes;
 import List;
 import Set;
 
-public Ranking analyzeVolume(set[LineCounts] facts)
+public VolumeAnalysisResult analyzeVolume(set[LineCounts] facts)
 {
-	if(size(facts) == 0) return VeryHigh(0);
+	if(size(facts) == 0) return <Rankings.veryHigh,0,0,0,0,facts>;
 	
-	int totalCount = sum({ x.code | x <- facts });
-	num totalKLoc = totalCount / 1000;
+	int codeLines = sum([ x.code | x <- facts ]);
+	num totalKLoc = codeLines / 1000;
+	int commentLines = sum([ x.comment | x <- facts ]);
+	int blankLines = sum([ x.blank | x <- facts ]);
+	int totalLines = sum([ x.total | x <- facts ]);
+	Rank ranking = Rankings.veryLow; // Pessimistic default.
 	
 	if (totalKLoc < 66) 
 	{
-		return VeryHigh(totalCount);
+		ranking = Rankings.veryHigh;
 	}
 	else if (totalKLoc < 246)
 	{
-		return High(totalCount);
+		ranking = Rankings.high;
 	}
 	else if (totalKLoc < 665)
 	{
-		return Moderate(totalCount);
+		ranking = Rankings.moderate;
 	}
 	else if (totalKLoc < 1310)
 	{
-		return Low(totalCount);
+		ranking = Rankings.low;
 	}
-	else
-	{
-		return VeryLow(totalCount);
-	}	
+	
+	return <ranking, totalLines, codeLines, blankLines, commentLines, facts>;	
 }

--- a/MaintainabilityAnalyzer/src/Analyzers/VolumeAnalyzer.rsc
+++ b/MaintainabilityAnalyzer/src/Analyzers/VolumeAnalyzer.rsc
@@ -10,10 +10,10 @@ public VolumeAnalysisResult analyzeVolume(set[LineCounts] facts)
 	if(size(facts) == 0) return <Rankings.veryHigh,0,0,0,0,facts>;
 	
 	int codeLines = sum([ x.code | x <- facts ]);
-	num totalKLoc = codeLines / 1000;
 	int commentLines = sum([ x.comment | x <- facts ]);
 	int blankLines = sum([ x.blank | x <- facts ]);
 	int totalLines = sum([ x.total | x <- facts ]);
+	num totalKLoc = codeLines / 1000;	
 	Rank ranking = Rankings.veryLow; // Pessimistic default.
 	
 	if (totalKLoc < 66) 
@@ -33,5 +33,5 @@ public VolumeAnalysisResult analyzeVolume(set[LineCounts] facts)
 		ranking = Rankings.low;
 	}
 	
-	return <ranking, totalLines, codeLines, blankLines, commentLines, facts>;	
+	return <ranking, totalLines, codeLines, blankLines, commentLines, facts>;
 }

--- a/MaintainabilityAnalyzer/src/DataTypes.rsc
+++ b/MaintainabilityAnalyzer/src/DataTypes.rsc
@@ -42,3 +42,5 @@ alias LineOfCode = tuple[str line, loc location];
 alias LinesOfCode = list[LineOfCode];
 
 alias Position = tuple[int line, int column];
+
+alias VolumeAnalysisResult = tuple[Rank ranking, int totalLinesOfCode, int codeLines, int blankLines, int commentLines, set[LineCounts] counts];

--- a/MaintainabilityAnalyzer/src/Extractors/LinesOfCodeExtractor.rsc
+++ b/MaintainabilityAnalyzer/src/Extractors/LinesOfCodeExtractor.rsc
@@ -6,6 +6,7 @@ import IO;
 import List;
 import Set;
 import String;
+import Utils::Normalizer;
 import DataTypes;
 
 /**
@@ -30,22 +31,12 @@ private int countBlankLines(list[str] lines) = size([x | x <- lines, trim(x) == 
  * @return A LineCounts instance containing the result of the calculation.
  */
 private LineCounts calculateLineCounts(loc file) {
-	M3 model = createM3FromFile(file);
-	str source = readFile(file);
-	list[str] lines = split("\n", source);	
-	int total = size(lines);
+	LinesOfCode normalized =  normalizeFile(file);
+	list[str] lines = readFileLines(file);
+	int total = size(lines);	
 	int blank = countBlankLines(lines);
-	int code = 0;
-	int comment = 0;
-	
-	// Straight forward calculation when there are no comments.
-	if (size(model.documentation) == 0) {
-		code = total - blank;
-	}
-	else {
-		code = calculateLinesOfCode(source, model);
-		comment = total - code - blank;		
-	}
+	int code = size(normalized);
+	int comment = total - code - blank;
 			
 	return <file, code, comment, blank, total>;	
 }

--- a/MaintainabilityAnalyzer/src/Main.rsc
+++ b/MaintainabilityAnalyzer/src/Main.rsc
@@ -42,11 +42,14 @@ public void run(loc project) {
 	
 	VolumeAnalysisResult volumeAnalysisResult = analyzeVolume(lineCounts);
 	
-	println("Calculated volume ranking: <volumeAnalysisResult.ranking.rank> (<volumeAnalysisResult.ranking.label>)");
+	println("VOLUME RANKING");
+	println();
 	println("Total <volumeAnalysisResult.totalLinesOfCode> lines of which:");
 	println("<volumeAnalysisResult.codeLines> lines of code");
 	println("<volumeAnalysisResult.commentLines> comment lines");
 	println("<volumeAnalysisResult.blankLines> blank lines");
+	println();
+	println("Calculated volume ranking: <volumeAnalysisResult.ranking.rank> (<volumeAnalysisResult.ranking.label>)");
 	
 	
 }

--- a/MaintainabilityAnalyzer/src/Main.rsc
+++ b/MaintainabilityAnalyzer/src/Main.rsc
@@ -39,8 +39,14 @@ public void run(loc project) {
 			duplicates = extractDuplications(linesOfCode, duplicates, 6);
 		}
 	}
-
-	println("Calculated volume ranking: <analyzeVolume(lineCounts)>");
+	
+	VolumeAnalysisResult volumeAnalysisResult = analyzeVolume(lineCounts);
+	
+	println("Calculated volume ranking: <volumeAnalysisResult.ranking.rank> (<volumeAnalysisResult.ranking.label>)");
+	println("Total <volumeAnalysisResult.totalLinesOfCode> lines of which:");
+	println("<volumeAnalysisResult.codeLines> lines of code");
+	println("<volumeAnalysisResult.commentLines> comment lines");
+	println("<volumeAnalysisResult.blankLines> blank lines");
 	
 	
 }

--- a/MaintainabilityAnalyzer/src/Tests/Extractors/LinesOfCodeExtractorTests.rsc
+++ b/MaintainabilityAnalyzer/src/Tests/Extractors/LinesOfCodeExtractorTests.rsc
@@ -1,6 +1,7 @@
 module Tests::Extractors::LinesOfCodeExtractorTests
 
 import Extractors::LinesOfCodeExtractor;
+import Utils::Normalizer;
 import lang::java::jdt::m3::Core;
 import DataTypes;
 import IO;
@@ -30,7 +31,7 @@ test bool extractLinesOfCode_Correctly_Calculates_Comment_Lines() {
 test bool extractLinesOfCode_Correctly_Calculates_Code_Lines() {	
 	LineCounts actual = extractLinesOfCode(fileSource);
 
-	return actual.code == 19;
+	return actual.code == 18;
 }
 
 test bool extractLinesOfCode_Correctly_Calculates_Total_Lines() {	 

--- a/MaintainabilityAnalyzer/src/Utils/Normalizer.rsc
+++ b/MaintainabilityAnalyzer/src/Utils/Normalizer.rsc
@@ -45,7 +45,14 @@ LinesOfCode normalizeFile(loc file) {
 		}
 		
 		// Create a source reference that points to the line of code.
-		loc src = createSourceReference(file, lineNumber, offset, index, size(tempLine));
+		loc src = file;
+		
+		try {
+			src = createSourceReference(file, lineNumber, offset, index, size(tempLine));
+		}
+		catch: {
+			src = file;
+		}
 		
 		// If the line is not a blank line, add it to the result.
 		// TODO: maybe do store blank line, but mark it as blank, so we can count them too...


### PR DESCRIPTION
It now uses the normalizer and keeps all the analysis results together in a single type alias.
Also made the output cleaner, it now includes the ranking data and line counts.